### PR TITLE
6.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flex-slider",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "slider ui component for react",
   "keywords": [
     "react",


### PR DESCRIPTION
Release a new version because `lib` wasn't included in the last version.