### PR TITLE
chore: set version to 6.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flex-slider",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "slider ui component for react",
   "keywords": [
     "react",


### PR DESCRIPTION
I already published 6.3.1 version on NPM. The 6.3.0 version was published with outdated lib/ and dist/ artifacts.